### PR TITLE
Migration for Yearn vault, reset replacementVault

### DIFF
--- a/contracts/instruments/RibbonThetaVault.sol
+++ b/contracts/instruments/RibbonThetaVault.sol
@@ -174,7 +174,6 @@ contract RibbonThetaVault is DSMath, OptionsVaultStorage {
      * @notice Closes the vault and makes it withdraw only.
      */
     function sunset(address upgradeTo) external onlyOwner {
-        require(address(replacementVault) == address(0), "Already sunset");
         require(upgradeTo != address(0), "!upgradeTo");
 
         replacementVault = IRibbonV2Vault(upgradeTo);

--- a/contracts/instruments/RibbonThetaVaultYearn.sol
+++ b/contracts/instruments/RibbonThetaVaultYearn.sol
@@ -17,6 +17,7 @@ import {IYearnRegistry, IYearnVault} from "../interfaces/IYearn.sol";
 import {ISwap, Types} from "../interfaces/ISwap.sol";
 import {OtokenInterface} from "../interfaces/GammaInterface.sol";
 import {OptionsVaultStorage} from "../storage/OptionsVaultStorage.sol";
+import {IRibbonV2Vault} from "../interfaces/IRibbonVaults.sol";
 
 contract RibbonThetaVaultYearn is DSMath, OptionsVaultStorage {
     using ProtocolAdapter for IProtocolAdapter;
@@ -76,6 +77,15 @@ contract RibbonThetaVaultYearn is DSMath, OptionsVaultStorage {
     event WithdrawalFeeSet(uint256 oldFee, uint256 newFee);
 
     event CapSet(uint256 oldCap, uint256 newCap, address manager);
+
+    event VaultSunset(address replacement);
+
+    event Migrate(
+        address account,
+        address replacement,
+        uint256 shares,
+        uint256 amount
+    );
 
     /**
      * @notice Initializes the contract with immutable variables
@@ -596,6 +606,43 @@ contract RibbonThetaVaultYearn is DSMath, OptionsVaultStorage {
         uint256 oldCap = cap;
         cap = newCap;
         emit CapSet(oldCap, newCap, msg.sender);
+    }
+
+    /**
+     * @notice Closes the vault and makes it withdraw only.
+     */
+    function sunset(address upgradeTo) external onlyOwner {
+        require(upgradeTo != address(0), "!upgradeTo");
+
+        replacementVault = IRibbonV2Vault(upgradeTo);
+
+        emit VaultSunset(upgradeTo);
+    }
+
+    /*
+     * @notice Moves msg.sender's deposited funds to new vault w/o fees
+     */
+    function migrate() external nonReentrant {
+        IRibbonV2Vault vault = replacementVault;
+        require(address(vault) != address(0), "Not sunset");
+
+        uint256 maxShares = maxWithdrawableShares();
+        uint256 share = balanceOf(msg.sender);
+        uint256 allShares = min(maxShares, share);
+
+        (uint256 withdrawAmount, uint256 feeAmount) =
+            withdrawAmountWithShares(allShares);
+
+        // Since we want to exclude fees, we add them both together
+        withdrawAmount = withdrawAmount.add(feeAmount);
+
+        emit Migrate(msg.sender, address(vault), allShares, withdrawAmount);
+
+        _burn(msg.sender, allShares);
+
+        IERC20(asset).safeApprove(address(vault), withdrawAmount);
+
+        vault.depositFor(withdrawAmount, msg.sender);
     }
 
     /**

--- a/contracts/instruments/RibbonThetaVaultYearn.sol
+++ b/contracts/instruments/RibbonThetaVaultYearn.sol
@@ -640,6 +640,8 @@ contract RibbonThetaVaultYearn is DSMath, OptionsVaultStorage {
 
         _burn(msg.sender, allShares);
 
+        _unwrapYieldToken(withdrawAmount);
+
         IERC20(asset).safeApprove(address(vault), withdrawAmount);
 
         vault.depositFor(withdrawAmount, msg.sender);

--- a/test/RibbonThetaVault.js
+++ b/test/RibbonThetaVault.js
@@ -2904,6 +2904,13 @@ function behavesLikeRibbonOptionsVault(params) {
         assert.equal(await this.vault.replacementVault(), this.v2vault.address);
       });
 
+      it("succeeds in resetting replacementVault", async function () {
+        await this.vault.connect(ownerSigner).sunset(owner);
+        await this.vault.connect(ownerSigner).sunset(this.v2vault.address);
+
+        assert.equal(await this.vault.replacementVault(), this.v2vault.address);
+      });
+
       it("deposits still work after sunset", async function () {
         await this.vault.connect(ownerSigner).sunset(this.v2vault.address);
         const depositAmount = BigNumber.from("10000000000");


### PR DESCRIPTION
- Added sunset/migrate function for Yearn vault
- Removed the yvETH vault tests (was breaking a few things related to deposit)
- Allowed resetting the replacement vault - this is needed because we plan to change the v1 ETH vault's replacement vault to stETH vault